### PR TITLE
taskモデルを作成してmigrate

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,2 @@
+class Task < ApplicationRecord
+end

--- a/db/migrate/20200616050900_create_tasks.rb
+++ b/db/migrate/20200616050900_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tasks do |t|
+      t.string   :name
+      t.text     :explanation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_06_16_050900) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name"
+    t.text "explanation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
## 概要

- taskモデルを作成しました。

- taskのmigrationファイルに名前と説明欄のカラムを追加してmigrateしました。

- 今回モデルを生成するにあたって叩いたコマンドは、「docker-compose run app rails generate model Task」です。

  - このコマンドを用いることで、dockerの複数のコンテナを組み合わせて１つのアプリケーションとして構成を定義するファイルである、docker-composeを指定して、その上でrails generate modelというモデルを生成するコマンドを実行し、Taskモデルを作成することができます。