### PR TITLE
factorybotを導入しタスクのテストデータを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     execjs (2.7.0)
+    factory_bot (6.0.2)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.0.0)
+      factory_bot (~> 6.0.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -213,6 +218,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :task  do
+        name { 'テスト' }
+        explanation { 'テストテスト' }
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,4 +81,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include SystemHelper, type: :system
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 対象step
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-factory-bot%E3%81%A7%E3%83%86%E3%82%B9%E3%83%88%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92%E4%BD%9C%E6%88%90%E3%81%97%E3%82%88%E3%81%86

## 概要
factorybotを導入し、`spec/factories/task.rb`にタスクのテストデータを作成しました。

## 実施した改修内容
- gem `factory_bot_rails` を追加
- `spec/factories/task.rb`を作成し、テストデータを作成

## 確認していただきたい点
- テストデータに不備がないかどうか