### PR TITLE
タスクに終了期限を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'rails-i18n'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'ransack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'pry-byebug'
 end
 
 group :development do
@@ -52,7 +53,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -139,6 +141,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -220,6 +227,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-i18n
+  ransack
   rspec-rails
   sass-rails (~> 5.0.7)
   selenium-webdriver

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :explanation)
+    params.require(:task).permit(:name, :explanation, :deadline)
   end
 
   def find_task

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,9 +2,9 @@ class TasksController < ApplicationController
   before_action :find_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @q = Task.ransack(params[:q])
-    @q.sorts = 'created_at desc' if @q.sorts.empty?
-    @tasks = @q.result(distinct: true)
+    @query = Task.ransack(params[:q])
+    @query.sorts = 'created_at desc' if @query.sorts.empty?
+    @tasks = @query.result(distinct: true)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   before_action :find_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order(created_at: "DESC")
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result(distinct: true)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,6 +3,7 @@ class TasksController < ApplicationController
 
   def index
     @q = Task.ransack(params[:q])
+    @q.sorts = 'created_at desc' if @q.sorts.empty?
     @tasks = @q.result(distinct: true)
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,6 +4,7 @@ class Task < ApplicationRecord
   validate :deadline_cannot_be_in_the_past
 
   def deadline_cannot_be_in_the_past
-    errors.add(:deadline, "は過去の日時は選択できません") if deadline < Time.now
+    return if deadline == nil
+    errors.add(:deadline, "は過去の日時は選択できません") if deadline < Time.now 
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,8 @@
 class Task < ApplicationRecord
+    validates :deadline, presence: true
+    validate :deadline_cannot_be_in_the_past
+
+    def deadline_cannot_be_in_the_past
+    errors.add(:deadline, "は過去の日時は選択できません") if deadline < Time.now
+    end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,10 +1,5 @@
 class Task < ApplicationRecord
   validates :name, presence: true
   validates :deadline, presence: true
-  validate :deadline_cannot_be_in_the_past
-
-  def deadline_cannot_be_in_the_past
-    return if deadline == nil
-    errors.add(:deadline, "は過去の日時は選択できません") if deadline < Time.now 
-  end
+  validates :deadline, datatime_past: true
 end

--- a/app/validators/datatime_past_validator.rb
+++ b/app/validators/datatime_past_validator.rb
@@ -1,0 +1,6 @@
+class DatatimePastValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value == nil
+    record.errors[attribute] << "は過去の日時は選択できません" if value < Time.now
+  end
+end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -3,5 +3,11 @@
   <%= f.text_field :name, value: @task.name %>
   <%= f.label :explanation, '説明' %>
   <%= f.text_area :explanation, value: @task.explanation %>
+  <%= f.label :deadline, '期限' %>
+  <% if @task.deadline.present? %>
+    <%= f.datetime_field :deadline, value: @task.deadline.iso8601.gsub(/\+..:..$/, '') %>
+  <% else %>
+    <%= f.datetime_field :deadline %>
+  <% end %>
   <%= f.submit '保存' %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,6 +5,7 @@
 <% @tasks.each do |task| %>
     <h2><%= task.name %></h2>
     <p><%= task.explanation %></p>
+    <p>期限 <%= task.deadline %></p>
     <p>作成日時：<%= task.created_at %></p>
     <p>更新日時：<%= task.updated_at %></p>
     <%= link_to '詳細', "/tasks/#{task.id}", method: :get %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= link_to '新規作成', "/tasks/new", method: :get %>
 
-<%= sort_link(@q, :deadline, "終了日時順") %>
+<%= sort_link(@q, :deadline, "期限順") %>
 
 <% @tasks.each do |task| %>
     <h2><%= task.name %></h2>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,8 @@
 
 <%= link_to '新規作成', "/tasks/new", method: :get %>
 
+<%= sort_link(@q, :deadline, "終了日時順") %>
+
 <% @tasks.each do |task| %>
     <h2><%= task.name %></h2>
     <p><%= task.explanation %></p>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= link_to '新規作成', "/tasks/new", method: :get %>
 
-<%= sort_link(@q, :deadline, "期限順") %>
+<%= sort_link(@query, :deadline, "期限順") %>
 
 <% @tasks.each do |task| %>
     <h2><%= task.name %></h2>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,6 +2,7 @@
 
 <h2><%= @task.name %></h2>
 <%= @task.explanation %>
+<p>期限 <%= @task.deadline %></p>
 
 <%= link_to '戻る', "/tasks", method: :get %>
 <%= link_to '編集', "/tasks/#{@task.id}/edit", method: :get %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,7 +60,9 @@ development:
 test:
   <<: *default
   database: app_test
-
+  username: <%= ENV['PG_USER'] %>
+  password: <%= ENV['PG_PASSWORD'] %>
+  host: db
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,4 +6,4 @@ ja:
         task:
           name: タスク名
           explanation: 説明
-          deadline: 終了期限
+          deadline: 期限

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,4 @@ ja:
         task:
           name: タスク名
           explanation: 説明
+          deadline: 終了期限

--- a/db/migrate/20200623030603_add_deadline_to_tasks.rb
+++ b/db/migrate/20200623030603_add_deadline_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDeadlineToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_050900) do
+ActiveRecord::Schema.define(version: 2020_06_23_030603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "explanation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deadline", null: false
   end
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     ports:
       - '80:3000'
     environment:
-      RAILS_ENV: development
       PG_DATABASE: postgres
       PG_PASSWORD: pass
       PG_USER: postgres

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
-    factory :task  do
-        name { 'テスト' }
-        explanation { 'テストテスト' }
-    end
+  factory :task  do
+    sequence(:name) { |n| "テスト#{n}" }
+    explanation { 'テストテスト' }
+    sequence(:deadline) { |n| Time.current + n.days }
+    sequence(:created_at) { |n| Time.current + (n - 1).days }
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Task, type: :model do
     subject { task.valid? }
 
     context 'when success' do
-      let(:params) { { name: 'テスト', explanation: 'テストテスト' } }
+      let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.tomorrow } }
 
       it 'validates successfully' do
         is_expected.to eq true
@@ -14,12 +14,30 @@ RSpec.describe Task, type: :model do
     end
 
     context 'when fail' do
-      context 'name column is nil' do
+      context 'name is nil' do
         let(:params) { { name: nil, explanation: 'テストテスト' } }
 
         it 'returns an error message' do
           is_expected.to eq false
           expect(task.errors[:name]).to include('を入力してください')
+        end
+      end
+
+      context 'deadline is nil' do
+        let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: nil } }
+
+        it 'returns an error message' do
+          is_expected.to eq false
+          expect(task.errors[:deadline]).to include('を入力してください')
+        end
+      end
+
+      context 'deadline is past' do
+        let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.yesterday } }
+
+        it 'returns an error message' do
+          is_expected.to eq false
+          expect(task.errors[:deadline]).to include('は過去の日時は選択できません')
         end
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe Task, type: :model do
       let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.tomorrow } }
 
       it 'validates successfully' do
-        is_expected.to eq true
+        expect(subject).to eq true
       end
     end
 
     context 'when fail' do
       context 'name is nil' do
-        let(:params) { { name: nil, explanation: 'テストテスト' } }
+        let(:params) { { name: nil, explanation: 'テストテスト', deadline: Time.current.tomorrow } }
 
         it 'returns an error message' do
-          is_expected.to eq false
+          expect(subject).to eq false
           expect(task.errors[:name]).to include('を入力してください')
         end
       end
@@ -27,7 +27,7 @@ RSpec.describe Task, type: :model do
         let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: nil } }
 
         it 'returns an error message' do
-          is_expected.to eq false
+          expect(subject).to eq false
           expect(task.errors[:deadline]).to include('を入力してください')
         end
       end
@@ -36,7 +36,7 @@ RSpec.describe Task, type: :model do
         let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.yesterday } }
 
         it 'returns an error message' do
-          is_expected.to eq false
+          expect(subject).to eq false
           expect(task.errors[:deadline]).to include('は過去の日時は選択できません')
         end
       end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -6,27 +6,25 @@ RSpec.describe 'Tasks', type: :system, js: true do
       create_list(:task, 4)
     end
 
+    before(:each) do
+      visit tasks_path
+    end
+
     subject do 
       task = all('h2')
       task_0 = task[0]
     end
 
-    before(:each) do
-      visit tasks_path
-    end
-
     context 'by default' do
       it 'sort by created_at' do
-        subject
         expect(subject).to have_content "テスト4"
         save_and_open_page
       end
     end
 
     context 'click 期限順' do
-      it 'sort by created_at' do
+      it 'sort by deadline' do
         click_on '期限順'
-        subject
         expect(subject).to have_content "テスト1"
         save_and_open_page
       end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,13 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system, js: true do
   describe 'order test in index' do
-    Task.destroy_all # 順番の正しさをタスク名で判断するため、全タスクを削除
-    Task.create(id: 1, name: 'テスト1', explanation: 'hi', deadline: Time.current.tomorrow)
-    Task.create(id: 2, name: 'テスト2', explanation: 'hihi2', deadline: Time.current + 2.days, created_at: Time.current + 1.days)
-    Task.create(id: 3, name: 'テスト3', explanation: 'hihi3', deadline: Time.current + 3.days, created_at: Time.current + 2.days)
-    Task.create(id: 4, name: 'テスト4', explanation: 'hihi4', deadline: Time.current + 4.days, created_at: Time.current + 3.days)
+    before(:all) do
+      create_list(:task, 4)
+    end
 
-    before do
+    before(:each) do
       visit tasks_path
     end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,16 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system, js: true do
-    it "作成日時の順番で並び替えができていること" do
-        Task.destroy_all
-        Task.create(id: 1, name: 'テスト1', explanation: 'hi')
-        Task.create(id: 2, name: 'テスト2', explanation: 'hihi2', created_at: Time.current + 1.days)
-        Task.create(id: 3, name: 'テスト3', explanation: 'hihi3', created_at: Time.current + 2.days)
-        Task.create(id: 4, name: 'テスト4', explanation: 'hihi4', created_at: Time.current + 3.days)
-        visit tasks_path
+  describe 'order test in index' do
+    Task.destroy_all # 順番の正しさをタスク名で判断するため、全タスクを削除
+    Task.create(id: 1, name: 'テスト1', explanation: 'hi', deadline: Time.current.tomorrow)
+    Task.create(id: 2, name: 'テスト2', explanation: 'hihi2', deadline: Time.current + 2.days, created_at: Time.current + 1.days)
+    Task.create(id: 3, name: 'テスト3', explanation: 'hihi3', deadline: Time.current + 3.days, created_at: Time.current + 2.days)
+    Task.create(id: 4, name: 'テスト4', explanation: 'hihi4', deadline: Time.current + 4.days, created_at: Time.current + 3.days)
+
+    before do
+      visit tasks_path
+    end
+
+    context 'by default' do
+      it 'sort by created_at' do
         task = all('h2')
         task_0 = task[0]
         expect(task_0).to have_content "テスト4"
         save_and_open_page
+      end
     end
+
+    context 'click 期限順' do
+      it 'sort by created_at' do
+        click_on '期限順'
+        task = all('h2')
+        task_0 = task[0]
+        expect(task_0).to have_content "テスト1"
+        save_and_open_page
+      end
+    end
+  end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -6,15 +6,19 @@ RSpec.describe 'Tasks', type: :system, js: true do
       create_list(:task, 4)
     end
 
+    subject do 
+      task = all('h2')
+      task_0 = task[0]
+    end
+
     before(:each) do
       visit tasks_path
     end
 
     context 'by default' do
       it 'sort by created_at' do
-        task = all('h2')
-        task_0 = task[0]
-        expect(task_0).to have_content "テスト4"
+        subject
+        expect(subject).to have_content "テスト4"
         save_and_open_page
       end
     end
@@ -22,9 +26,8 @@ RSpec.describe 'Tasks', type: :system, js: true do
     context 'click 期限順' do
       it 'sort by created_at' do
         click_on '期限順'
-        task = all('h2')
-        task_0 = task[0]
-        expect(task_0).to have_content "テスト1"
+        subject
+        expect(subject).to have_content "テスト1"
         save_and_open_page
       end
     end


### PR DESCRIPTION
## 対象step
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9716-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86

## 概要
タスクに終了期限を設定できるようにしました。空の場合と過去の日時の場合は登録できないようにし、さらに終了期限でソートができるようにもしてあります。

## 実施した改修内容
- ソートの為、gemのransackをインストール
- ソートできるように`tasks_controller`のindexメソッドにransackを組み込み
- deadlineカラムをnot null制約つきで追加し、空の場合と過去の日時の場合でバリデーションを付与
- viewファイルに期限関係のコードを追加
- `spec/models/task_spec.rb`に期限関係のテスト追加
- `spec/system/tasks_spec.rb`に期限関係のテスト追加

## 確認していただきたい点
- バリデーションに不備がないかどうか
- `spec/models/task_spec.rb`に不備がないかどうか
- `spec/system/tasks_spec.rb`に不備がないかどうか