### PR TITLE
タスクにステータスを追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -47,7 +47,9 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :explanation, :deadline, :status)
+    params.require(:task).permit(
+      :name, :explanation, :deadline, :status
+    )
   end
 
   def find_task

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -45,7 +45,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :explanation)
+    params.require(:task).permit(:name, :explanation, :status)
   end
 
   def find_task

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,7 +8,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   def self.enums_i18n(enum_name)
     self.send(enum_name.to_s.pluralize).map do |key, value|
-      [I18n.t!("enums.#{self.model_name.i18n_key}.#{enum_name}.#{key}"), value]
+      [I18n.t!("enums.#{self.model_name.i18n_key}.#{enum_name}.#{key}"), key]
     end.to_h
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,14 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def enum_i18n(enum_name)
+    return nil if self.send(enum_name).nil?
+    I18n.t!("enums.#{self.model_name.i18n_key}.#{enum_name}.#{self.send(enum_name)}")
+  end
+
+  def self.enums_i18n(enum_name)
+    self.send(enum_name.to_s.pluralize).map do |key, value|
+      [I18n.t!("enums.#{self.model_name.i18n_key}.#{enum_name}.#{key}"), value]
+    end.to_h
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,5 @@
 class Task < ApplicationRecord
-    validates :name, presence: true
+  enum status: { not_started: 0, in_progress: 1, completed: 2 }
+
+  validates :name, presence: true
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -4,5 +4,7 @@
   <%= f.text_field :name, value: @task.name %>
   <%= f.label :explanation, '説明' %>
   <%= f.text_area :explanation, value: @task.explanation %>
+  <%= f.label :status, '状態' %>
+  <%= f.select :status, Task.enums_i18n(:status) %>
   <%= f.submit '保存' %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,17 @@
 <h1>タスク一覧</h1>
 
+<%= search_form_for @query do |f| %>
+  <%= f.label :name, "タスク名" %>
+  <%= f.search_field :name_cont %>
+  <%= f.label :status, "状態" %>
+　<%= f.radio_button :status_eq, '', { checked: true } %>指定なし
+  <%= f.radio_button :status_eq, 0 %>未着手
+  <%= f.radio_button :status_eq, 1 %>着手中
+  <%= f.radio_button :status_eq, 2 %>完了
+
+  <%= f.submit "検索" %>
+<% end %>
+
 <%= link_to '新規作成', "/tasks/new", method: :get %>
 
 <%= sort_link(@query, :deadline, "期限順") %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,6 +5,7 @@
 <% @tasks.each do |task| %>
     <h2><%= task.name %></h2>
     <p><%= task.explanation %></p>
+    <p>状態：<%= task.enum_i18n(:status) %></p>
     <p>作成日時：<%= task.created_at %></p>
     <p>更新日時：<%= task.updated_at %></p>
     <%= link_to '詳細', "/tasks/#{task.id}", method: :get %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,6 +2,7 @@
 
 <h2><%= @task.name %></h2>
 <%= @task.explanation %>
+<p>状態：<%= @task.enum_i18n(:status) %></p>
 
 <%= link_to '戻る', "/tasks", method: :get %>
 <%= link_to '編集', "/tasks/#{@task.id}/edit", method: :get %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,9 @@ ja:
         task:
           name: タスク名
           explanation: 説明
+    enums:
+      task:
+        status:
+          not_started: 未着手
+          in_progress: 着手中
+          completed: 完了

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,4 @@ ja:
           not_started: 未着手
           in_progress: 着手中
           completed: 完了
+          

--- a/db/migrate/20200626050901_add_status_to_tasks.rb
+++ b/db/migrate/20200626050901_add_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :status, :integer, null: false
+  end
+end

--- a/db/migrate/20200626054640_change_status_default.rb
+++ b/db/migrate/20200626054640_change_status_default.rb
@@ -1,0 +1,5 @@
+class ChangeStatusDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :tasks, :status, 0
+  end
+end

--- a/db/migrate/20200629050755_add_index_tasks_name_and_status.rb
+++ b/db/migrate/20200629050755_add_index_tasks_name_and_status.rb
@@ -1,0 +1,6 @@
+class AddIndexTasksNameAndStatus < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :name
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,8 +20,8 @@ ActiveRecord::Schema.define(version: 2020_06_26_054640) do
     t.text "explanation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status", default: 0, null: false
     t.datetime "deadline", null: false
+    t.integer "status", default: 0, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_083631) do
+ActiveRecord::Schema.define(version: 2020_06_26_054640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_083631) do
     t.text "explanation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_054640) do
+ActiveRecord::Schema.define(version: 2020_06_29_050755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2020_06_26_054640) do
     t.datetime "updated_at", null: false
     t.datetime "deadline", null: false
     t.integer "status", default: 0, null: false
+    t.index ["name"], name: "index_tasks_on_name"
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,21 +2,21 @@
   Task.create!(
     name: "テスト未着手#{n + 1}",
     explanation: "テストテスト",
-    status: 0,
+    status: "not_started",
     deadline: Time.current + (n + 1).days
   )
 
   Task.create!(
     name: "テスト着手中#{n + 1}",
     explanation: "テストテスト",
-    status: 1,
+    status: "in_progress",
     deadline: Time.current + (n + 1).days
   )
 
   Task.create!(
     name: "テスト完了#{n + 1}",
     explanation: "テストテスト",
-    status: 2,
+    status: "completed",
     deadline: Time.current + (n + 1).days
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,22 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+20.times do |n|
+  Task.create!(
+    name: "テスト未着手#{n + 1}",
+    explanation: "テストテスト",
+    status: 0,
+    deadline: Time.current + (n + 1).days
+  )
+
+  Task.create!(
+    name: "テスト着手中#{n + 1}",
+    explanation: "テストテスト",
+    status: 1,
+    deadline: Time.current + (n + 1).days
+  )
+
+  Task.create!(
+    name: "テスト完了#{n + 1}",
+    explanation: "テストテスト",
+    status: 2,
+    deadline: Time.current + (n + 1).days
+  )
+end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,25 +1,17 @@
 FactoryBot.define do
-  factory :task_A, class: Task  do
-    sequence(:name) { |n| "テストA-#{n}" }
+  factory :task do
+    sequence(:name) { |n| "テスト#{n}" }
     explanation { 'テストテスト' }
-    status { 0 }
+    status { "not_started" }
     sequence(:deadline) { |n| Time.current + n.days }
     sequence(:created_at) { |n| Time.current + (n - 1).days }
-  end
 
-  factory :task_B, class: Task  do
-    sequence(:name) { |n| "テストB-#{n}" }
-    explanation { 'テストテスト' }
-    status { 1 }
-    sequence(:deadline) { |n| Time.current + n.days }
-    sequence(:created_at) { |n| Time.current + (n - 1).days }
-  end
+    trait :in_progress do
+      status { "in_progress" }
+    end
 
-  factory :task_C, class: Task  do
-    sequence(:name) { |n| "テストC-#{n}" }
-    explanation { 'テストテスト' }
-    status { 2 }
-    sequence(:deadline) { |n| Time.current + n.days }
-    sequence(:created_at) { |n| Time.current + (n - 1).days }
+    trait :completed do
+      status { "completed" }
+    end
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,7 +1,24 @@
 FactoryBot.define do
-  factory :task  do
-    sequence(:name) { |n| "テスト#{n}" }
+  factory :task_A, class: Task  do
+    sequence(:name) { |n| "テストA-#{n}" }
     explanation { 'テストテスト' }
+    status { 0 }
+    sequence(:deadline) { |n| Time.current + n.days }
+    sequence(:created_at) { |n| Time.current + (n - 1).days }
+  end
+
+  factory :task_B, class: Task  do
+    sequence(:name) { |n| "テストB-#{n}" }
+    explanation { 'テストテスト' }
+    status { 1 }
+    sequence(:deadline) { |n| Time.current + n.days }
+    sequence(:created_at) { |n| Time.current + (n - 1).days }
+  end
+
+  factory :task_C, class: Task  do
+    sequence(:name) { |n| "テストC-#{n}" }
+    explanation { 'テストテスト' }
+    status { 2 }
     sequence(:deadline) { |n| Time.current + n.days }
     sequence(:created_at) { |n| Time.current + (n - 1).days }
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -42,43 +42,4 @@ RSpec.describe Task, type: :model do
       end
     end
   end
-
-  describe 'search test' do
-    before(:each) do
-      create_list(:task_A, 3)
-      create_list(:task_B, 3)
-      create_list(:task_C, 3)
-    end
-
-    let(:task) { described_class.ransack(query) }
-    subject { task.result }
-
-    context 'search by name' do
-      let(:query) { { "name_cont" => "テストA" } }
-
-      it 'returns correct result' do
-        expect(subject.length).to eq 3
-        expect(subject[0].name).to eq "テストA-1"
-      end
-    end
-
-    context 'search by status' do
-      let(:query) { { "status_eq" => "1" } }
-
-      it 'returns correct result' do
-        expect(subject.length).to eq 3
-        expect(subject[0].status).to eq "in_progress"
-      end
-    end
-
-    context 'search by name and status' do
-      let(:query) { { "name_cont" => "テストC", "status_eq" => "2" } }
-
-      it 'returns correct result' do
-        expect(subject.length).to eq 3
-        expect(subject[0].name).to eq "テストC-7"
-        expect(subject[0].status).to eq "completed"
-      end
-    end
-  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Task, type: :model do
     subject { task.valid? }
 
     context 'when success' do
-      let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.tomorrow } }
+      let(:params) { { name: 'テスト', explanation: 'テストテスト', status: 0, deadline: Time.current.tomorrow } }
 
       it 'validates successfully' do
         expect(subject).to eq true
@@ -15,7 +15,7 @@ RSpec.describe Task, type: :model do
 
     context 'when fail' do
       context 'name is nil' do
-        let(:params) { { name: nil, explanation: 'テストテスト', deadline: Time.current.tomorrow } }
+        let(:params) { { name: nil, explanation: 'テストテスト', status: 0, deadline: Time.current.tomorrow } }
 
         it 'returns an error message' do
           expect(subject).to eq false
@@ -24,7 +24,7 @@ RSpec.describe Task, type: :model do
       end
 
       context 'deadline is nil' do
-        let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: nil } }
+        let(:params) { { name: 'テスト', explanation: 'テストテスト', status: 0, deadline: nil } }
 
         it 'returns an error message' do
           expect(subject).to eq false
@@ -33,12 +33,51 @@ RSpec.describe Task, type: :model do
       end
 
       context 'deadline is past' do
-        let(:params) { { name: 'テスト', explanation: 'テストテスト', deadline: Time.current.yesterday } }
+        let(:params) { { name: 'テスト', explanation: 'テストテスト', status: 0, deadline: Time.current.yesterday } }
 
         it 'returns an error message' do
           expect(subject).to eq false
           expect(task.errors[:deadline]).to include('は過去の日時は選択できません')
         end
+      end
+    end
+  end
+
+  describe 'search test' do
+    before(:each) do
+      create_list(:task_A, 3)
+      create_list(:task_B, 3)
+      create_list(:task_C, 3)
+    end
+
+    let(:task) { described_class.ransack(query) }
+    subject { task.result }
+
+    context 'search by name' do
+      let(:query) { { "name_cont" => "テストA" } }
+
+      it 'returns correct result' do
+        expect(subject.length).to eq 3
+        expect(subject[0].name).to eq "テストA-1"
+      end
+    end
+
+    context 'search by status' do
+      let(:query) { { "status_eq" => "1" } }
+
+      it 'returns correct result' do
+        expect(subject.length).to eq 3
+        expect(subject[0].status).to eq "in_progress"
+      end
+    end
+
+    context 'search by name and status' do
+      let(:query) { { "name_cont" => "テストC", "status_eq" => "2" } }
+
+      it 'returns correct result' do
+        expect(subject.length).to eq 3
+        expect(subject[0].name).to eq "テストC-7"
+        expect(subject[0].status).to eq "completed"
       end
     end
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,9 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system, js: true do
   describe 'order test in index' do
+    before(:all) do
+      create_list(:task, 4)
+    end
+
     before(:each) do
-      create_list(:task_A, 4)
       visit tasks_path
+    end
+
+    after(:all) do
+      Task.destroy_all
     end
 
     subject do 
@@ -14,7 +21,7 @@ RSpec.describe 'Tasks', type: :system, js: true do
 
     context 'by default' do
       it 'sort by created_at' do
-        expect(subject).to have_content "テストA-4"
+        expect(subject).to have_content "テスト4"
         save_and_open_page
       end
     end
@@ -22,18 +29,25 @@ RSpec.describe 'Tasks', type: :system, js: true do
     context 'click 期限順' do
       it 'sort by deadline' do
         click_on '期限順'
-        expect(subject).to have_content "テストA-5"
+        expect(subject).to have_content "テスト1"
         save_and_open_page
       end
     end
   end
 
   describe 'search test in index' do
+    before(:all) do
+      create_list(:task, 3, name: "テストA")
+      create_list(:task, 3, :in_progress, name: "テストB")
+      create_list(:task, 3, :completed, name: "テストC")
+    end
+
     before(:each) do
-      create_list(:task_A, 3)
-      create_list(:task_B, 3)
-      create_list(:task_C, 3)
       visit tasks_path
+    end
+
+    after(:all) do
+      Task.destroy_all
     end
 
     subject do
@@ -46,7 +60,7 @@ RSpec.describe 'Tasks', type: :system, js: true do
       let(:task_name) { 'テストA' }
 
       it 'displays correct result' do
-        expect(page).to have_content "テストA-9"
+        expect(page).to have_content "テストA"
         save_and_open_page
       end
     end
@@ -65,7 +79,7 @@ RSpec.describe 'Tasks', type: :system, js: true do
       let(:status) { 'q_status_eq_2' }
 
       it 'displays correct result' do
-        expect(page).to have_content "テストC-9"
+        expect(page).to have_content "テストC"
         expect(page).to have_content '状態：完了'
         save_and_open_page
       end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,11 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system, js: true do
   describe 'order test in index' do
-    before(:all) do
-      create_list(:task, 4)
-    end
-
     before(:each) do
+      create_list(:task_A, 4)
       visit tasks_path
     end
 
@@ -17,7 +14,7 @@ RSpec.describe 'Tasks', type: :system, js: true do
 
     context 'by default' do
       it 'sort by created_at' do
-        expect(subject).to have_content "テスト4"
+        expect(subject).to have_content "テストA-4"
         save_and_open_page
       end
     end
@@ -25,7 +22,51 @@ RSpec.describe 'Tasks', type: :system, js: true do
     context 'click 期限順' do
       it 'sort by deadline' do
         click_on '期限順'
-        expect(subject).to have_content "テスト1"
+        expect(subject).to have_content "テストA-5"
+        save_and_open_page
+      end
+    end
+  end
+
+  describe 'search test in index' do
+    before(:each) do
+      create_list(:task_A, 3)
+      create_list(:task_B, 3)
+      create_list(:task_C, 3)
+      visit tasks_path
+    end
+
+    subject do
+      fill_in 'q[name_cont]', with: task_name
+      choose status
+      click_button '検索'
+    end
+
+    context 'search by name' do
+      let(:task_name) { 'テストA' }
+
+      it 'displays correct result' do
+        expect(page).to have_content "テストA-9"
+        save_and_open_page
+      end
+    end
+
+    context 'search by status' do
+      let(:status) { 'q_status_eq_1' }
+
+      it 'displays correct result' do
+        expect(page).to have_content '状態：着手中'
+        save_and_open_page
+      end
+    end
+
+    context 'search by name and status' do
+      let(:task_name) { 'テストC' }
+      let(:status) { 'q_status_eq_2' }
+
+      it 'displays correct result' do
+        expect(page).to have_content "テストC-9"
+        expect(page).to have_content '状態：完了'
         save_and_open_page
       end
     end


### PR DESCRIPTION
## 対象step
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86

## 概要
ステータス（未着手、着手中、完了）をタスクに設定できるようにし、タスク一覧ページでタスク名とステータスで検索ができるようにして、さらに検索に関してテストを実装しました。

## 実施した改修内容
- statusカラムをTaskモデルに追加
- ransackを用いてタスク名とステータスでの検索機能を実装
- 検索速度向上のためタスク名とステータスに検索インデックスを付与
- タスクのmodel specとsystem specを追記

## 確認していただきたい点
- statusカラムの実装の仕方に問題がないかどうか（enumを使用しております）
- 検索機能に不備がないかどうか
- テストに不備がないかどうか
