### PR TITLE
ページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'rails-i18n'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -220,6 +232,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)
   pry-byebug

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :find_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order(created_at: "DESC")
+    @tasks = Task.all.order(created_at: "DESC").page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -9,3 +9,5 @@
     <p>更新日時：<%= task.updated_at %></p>
     <%= link_to '詳細', "/tasks/#{task.id}", method: :get %>
 <% end %>
+
+<%= paginate @tasks %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,10 @@ ja:
         task:
           name: タスク名
           explanation: 説明
+    views:
+      pagination:
+        first: "&laquo; 最初"
+        last: "最後 &raquo;"
+        previous: "&lsaquo; 前"
+        next: "次 &rsaquo;"
+        truncate: "..."


### PR DESCRIPTION
## 対象step
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86

## 概要
`gem 'kaminari'`を導入し、タスク一覧ページにページネーションを追加しました。

## 実施した改修内容
- `gem 'kaminari'`を導入
- `tasks_controller`の`index`メソッドにページネーション関係の記述を追加
- `tasks/index.html.erb`にページネーション関係の記述を追加
- `locales/ja.yml`にてページネーションの日本語化に対応

## 確認していただきたい点
- ページネーション関係の記述に過不足がないかどうか
