### PR TITLE
bootstrapを導入しデザインを調整

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+ h1 {
+   font-size: 2rem;
+ }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,3 +1,10 @@
 // Place all the styles related to the Tasks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+  .width-18rem {
+    width: 18rem;
+  }
+
+  .width-30rem {
+    width: 30rem;
+  }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,10 +1,15 @@
 // Place all the styles related to the Tasks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-  .width-18rem {
-    width: 18rem;
-  }
-
   .width-30rem {
     width: 30rem;
+  }
+
+  .width-40rem {
+    width: 40rem;
+  }
+
+  .pagination {
+    justify-content: center;
+    margin-top: 40px;
   }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,12 +1,14 @@
 // Place all the styles related to the Tasks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-  .width-30rem {
-    width: 30rem;
-  }
+  .width {
+    &-30rem {
+      width: 30rem;
+    }
 
-  .width-40rem {
-    width: 40rem;
+    &-40rem {
+      width: 40rem;
+    }
   }
 
   .pagination {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   def index
     @query = Task.ransack(params[:q])
     @query.sorts = 'created_at desc' if @query.sorts.empty?
-    @tasks = @query.result(distinct: true).page(params[:page]).per(10)
+    @tasks = @query.result(distinct: true).page(params[:page]).per(5)
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -2,7 +2,7 @@
   <div>
     <ul>
       <% model.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="text-danger"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
   </head>
@@ -14,5 +16,9 @@
     <%= alert %>
 
     <%= yield %>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,17 @@
   </head>
 
   <body>
-    <%= notice %>
-    <%= alert %>
+    <% flash.each do |message_type, message| %>
+      <% if message_type == "notice" %>
+        <div class="alert alert-success">
+          <%= message %>
+        </div>
+      <% else %>
+        <div class="alert alert-danger">
+          <%= message %>
+        </div>
+      <% end %>
+    <% end %>
 
     <%= yield %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,17 +14,19 @@
   <body>
     <% flash.each do |message_type, message| %>
       <% if message_type == "notice" %>
-        <div class="alert alert-success">
+        <div class="alert alert-success text-center">
           <%= message %>
         </div>
       <% else %>
-        <div class="alert alert-danger">
+        <div class="alert alert-danger text-center">
           <%= message %>
         </div>
       <% end %>
     <% end %>
 
-    <%= yield %>
+    <div class="container">
+      <%= yield %>
+    </div>
 
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,14 +1,30 @@
-<%= form_with(model: @task, local: true) do |f| %>
+<%= form_with(model: @task, local: true, class: "width-30rem") do |f| %>
   <%= render 'layouts/error_messages', model: @task %>
-  <%= f.label :name, '名前' %>
-  <%= f.text_field :name, value: @task.name %>
-  <%= f.label :explanation, '説明' %>
-  <%= f.text_area :explanation, value: @task.explanation %>
-  <%= f.label :deadline, '期限' %>
-  <% if @task.deadline.present? %>
-    <%= f.datetime_field :deadline, value: @task.deadline.iso8601.gsub(/\+..:..$/, '') %>
+
+  <div class="form-group">
+    <%= f.label :name, '名前' %>
+    <%= f.text_field :name, value: @task.name, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :explanation, '説明' %>
+    <%= f.text_area :explanation, value: @task.explanation, rows: 5, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :deadline, '期限' %>
+    <% if @task.deadline.present? %>
+      <%= f.datetime_field :deadline, value: @task.deadline.iso8601.gsub(/\+..:..$/, ''), class: "form-control" %>
+    <% else %>
+      <%= f.datetime_field :deadline, class: "form-control" %>
+    <% end %>
+  </div>
+
+  <% if request.fullpath == "/tasks/new" %>
+    <%= link_to '戻る', "/tasks", method: :get, class: "btn btn-outline-primary" %>
   <% else %>
-    <%= f.datetime_field :deadline %>
+    <%= link_to '戻る', "/tasks/#{@task.id}", method: :get, class: "btn btn-outline-primary" %>
   <% end %>
-  <%= f.submit '保存' %>
+
+  <%= f.submit '保存', class: "btn btn-outline-success" %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @task, local: true, class: "width-30rem") do |f| %>
+<%= form_with(model: @task, local: true, class: "width-40rem mx-auto") do |f| %>
   <%= render 'layouts/error_messages', model: @task %>
 
   <div class="form-group">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="form-group">
     <%= f.label :status, '状態' %>
-    <%= f.select :status, Task.enums_i18n(:status), class: "form-control" %>
+    <%= f.select :status, Task.enums_i18n(:status), {}, class: "form-control" %>
   </div>
 
   <div class="form-group">

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>タスクを編集</h1>
+<h1 class="text-center mt-3">タスクを編集</h1>
 
 <%= render 'form' %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,3 @@
 <h1>タスクを編集</h1>
 
 <%= render 'form' %>
-
-<%= link_to '戻る', "/tasks/#{@task.id}", method: :get %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,17 +1,30 @@
 <div class="text-center mt-3">
   <h1>タスク一覧</h1>
 
-  <div class="my-3">
-    <%= search_form_for @query do |f| %>
-      <%= f.label :name, "タスク名" %>
-      <%= f.search_field :name_cont %>
-      <%= f.label :status, "状態" %>
-      <%= f.radio_button :status_eq, '', { checked: true } %>指定なし
-      <%= f.radio_button :status_eq, 0 %>未着手
-      <%= f.radio_button :status_eq, 1 %>着手中
-      <%= f.radio_button :status_eq, 2 %>完了
+  <div class="py-3">
+    <%= search_form_for @query, html: { class: 'd-flex justify-content-center pb-2' } do |f| %>
+      <div class="form-group mr-2">
+        <%= f.label :name, "タスク名", { class: "mr-2" } %>
+        <%= f.search_field :name_cont %>
+      </div>
 
-      <%= f.submit "検索" %>
+      <div class="d-flex mr-3">
+        <%= f.label :status, "状態", { class: "mr-2" } %>
+
+        <div class="form-check mr-2">
+          <%= f.radio_button :status_eq, '', { checked: true, class: "form-check-input" } %>
+          <%= f.label :status_eq, "指定なし", {}, { class: "form-check-label" } %>
+        </div>
+
+        <% for num in 0..2 do %>
+          <div class="form-check mr-2">
+            <%= f.radio_button :status_eq, num, { class: "form-check-input" } %>
+            <%= f.label :status_eq, Task.enums_i18n(:status).keys[num], {}, { class: "form-check-label" } %>
+          </div>
+        <% end %>
+      </div>
+
+      <%= f.submit "検索", class: "btn btn-primary h-50" %>
     <% end %>
     <%= link_to '新規作成', "/tasks/new", method: :get, class: "btn btn-outline-success mr-2" %>
     <%= sort_link(@query, :deadline, "期限順") %>
@@ -27,7 +40,7 @@
     <h5 class="card-title ml-2 mt-2"><%= task.name %></h5>
 
     <div class="d-flex justify-content-end">
-      <p class="card-text mr-4"><small class="text-muted">task.enum_i18n(:status)</small></p>
+      <p class="card-text mr-4"><small class="font-weight-bold"><%= task.enum_i18n(:status) %></small></p>
       <p class="card-text mr-4"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
       <%= link_to '詳細', "/tasks/#{task.id}", method: :get, class: "card-link mr-4" %>
     </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,10 +7,12 @@
 
 <% @tasks.each do |task| %>
   <div class="card mb-2" style="width: 18rem;">
+    <div class="card-header">
+      期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %>
+    </div>
     <div class="card-body">
       <h5 class="card-title"><%= task.name %></h5>
       <p class="card-text"><%= task.explanation %></p>
-      <p class="card-text"><small class="text-muted">期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %></small></p>
       <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
 
       <% if task.created_at != task.updated_at %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -10,15 +10,10 @@
     <div class="card-header">
       期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %>
     </div>
+    
     <div class="card-body">
       <h5 class="card-title"><%= task.name %></h5>
-      <p class="card-text"><%= task.explanation %></p>
       <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
-
-      <% if task.created_at != task.updated_at %>
-        <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.updated_at) %>前に更新</small></p>
-      <% end %>
-
       <%= link_to '詳細', "/tasks/#{task.id}", method: :get, class: "card-link" %>
     </div>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,20 +1,23 @@
-<h1>タスク一覧</h1>
+<div class="text-center mt-3">
+  <h1>タスク一覧</h1>
 
-<div class="my-3">
-  <%= link_to '新規作成', "/tasks/new", method: :get, class: "btn btn-outline-success mr-2" %>
-  <%= sort_link(@query, :deadline, "期限順") %>
+  <div class="my-3">
+    <%= link_to '新規作成', "/tasks/new", method: :get, class: "btn btn-outline-success mr-2" %>
+    <%= sort_link(@query, :deadline, "期限順") %>
+  </div>
 </div>
 
 <% @tasks.each do |task| %>
-  <div class="card mb-2 width-18rem">
+  <div class="card mb-2 width-30rem mx-auto">
     <div class="card-header">
       期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %>
     </div>
 
-    <div class="card-body">
-      <h5 class="card-title"><%= task.name %></h5>
-      <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
-      <%= link_to '詳細', "/tasks/#{task.id}", method: :get, class: "card-link" %>
+    <h5 class="card-title ml-2 mt-2"><%= task.name %></h5>
+
+    <div class="d-flex justify-content-end">
+      <p class="card-text mr-4"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
+      <%= link_to '詳細', "/tasks/#{task.id}", method: :get, class: "card-link mr-4" %>
     </div>
   </div>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,16 +1,25 @@
-<h1>タスク一覧</h1>
+<h2>タスク一覧</h2>
 
-<%= link_to '新規作成', "/tasks/new", method: :get %>
-
-<%= sort_link(@query, :deadline, "期限順") %>
+<div class="my-3">
+  <%= link_to '新規作成', "/tasks/new", method: :get, class: "btn btn-outline-success mr-2" %>
+  <%= sort_link(@query, :deadline, "期限順") %>
+</div>
 
 <% @tasks.each do |task| %>
-    <h2><%= task.name %></h2>
-    <p><%= task.explanation %></p>
-    <p>期限 <%= task.deadline %></p>
-    <p>作成日時：<%= task.created_at %></p>
-    <p>更新日時：<%= task.updated_at %></p>
-    <%= link_to '詳細', "/tasks/#{task.id}", method: :get %>
+  <div class="card mb-2" style="width: 18rem;">
+    <div class="card-body">
+      <h5 class="card-title"><%= task.name %></h5>
+      <p class="card-text"><%= task.explanation %></p>
+      <p class="card-text"><small class="text-muted">期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %></small></p>
+      <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>
+
+      <% if task.created_at != task.updated_at %>
+        <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.updated_at) %>前に更新</small></p>
+      <% end %>
+
+      <%= link_to '詳細', "/tasks/#{task.id}", method: :get, class: "card-link" %>
+    </div>
+  </div>
 <% end %>
 
 <%= paginate @tasks %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<h2>タスク一覧</h2>
+<h1>タスク一覧</h1>
 
 <div class="my-3">
   <%= link_to '新規作成', "/tasks/new", method: :get, class: "btn btn-outline-success mr-2" %>
@@ -10,7 +10,7 @@
     <div class="card-header">
       期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %>
     </div>
-    
+
     <div class="card-body">
       <h5 class="card-title"><%= task.name %></h5>
       <p class="card-text"><small class="text-muted"><%= time_ago_in_words(task.created_at) %>前に作成</small></p>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <% @tasks.each do |task| %>
-  <div class="card mb-2" style="width: 18rem;">
+  <div class="card mb-2 width-18rem">
     <div class="card-header">
       期限：<%= (task.deadline.year == Time.current.year) ? (l task.deadline, format: :short) : (l task.deadline) %>
     </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,3 +1,3 @@
-<h1>新規タスク</h1>
+<h1 class="text-center mt-3">新規タスク</h1>
 
 <%= render 'form' %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,3 @@
 <h1>新規タスク</h1>
 
 <%= render 'form' %>
-
-<%= link_to '戻る', "/tasks", method: :get %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,10 +1,19 @@
-<h1>タスク詳細</h1>
+<div class="card" style="width: 30rem;">
+  <div class="card-header">
+    <p class="card-text">タスク詳細</p>
+  </div>
+  <div class="card-body">
+    <h5 class="card-title"><%= @task.name %></h5>
+    <p class="card-text"><%= @task.explanation %></p>
+    <p class="card-text">期限：<%= (@task.deadline.year == Time.current.year) ? (l @task.deadline, format: :short) : (l @task.deadline) %></p>
+    <p class="card-text"><small class="text-muted"><%= time_ago_in_words(@task.created_at) %>前に作成</small></p>
 
-<h2><%= @task.name %></h2>
-<%= @task.explanation %>
-<p>期限 <%= @task.deadline %></p>
+    <% if @task.created_at != @task.updated_at %>
+      <p class="card-text"><small class="text-muted"><%= time_ago_in_words(@task.updated_at) %>前に更新</small></p>
+    <% end %>
 
-<%= link_to '戻る', "/tasks", method: :get %>
-<%= link_to '編集', "/tasks/#{@task.id}/edit", method: :get %>
-<%= link_to '削除', "/tasks/#{@task.id}", method: :delete %>
-
+    <%= link_to '戻る', "/tasks", method: :get, class: "btn btn-outline-primary" %>
+    <%= link_to '編集', "/tasks/#{@task.id}/edit", method: :get, class: "btn btn-outline-success" %>
+    <%= link_to '削除', "/tasks/#{@task.id}", method: :delete, class: "btn btn-outline-danger" %>
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,4 @@
-<div class="card" style="width: 30rem;">
+<div class="card width-30rem">
   <div class="card-header">
     <p class="card-text">タスク詳細</p>
   </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,4 @@
-<div class="card width-30rem">
+<div class="card width-40rem mx-auto mt-3">
   <div class="card-header">
     <p class="card-text">タスク詳細</p>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,3 +14,43 @@ ja:
         previous: "&lsaquo; 前"
         next: "次 &rsaquo;"
         truncate: "..."
+    time:
+      formats:
+        default: "%Y/%m/%d %H:%M"
+        short: "%m/%d %H:%M"
+    datetime:
+      distance_in_words:
+        half_a_minute: "30秒前後"
+        less_than_x_seconds:
+          one:   "1秒"
+          other: "%{count}秒"
+        x_seconds:
+          one:   "1秒"
+          other: "%{count}秒"
+        less_than_x_minutes:
+          one:   "1分"
+          other: "%{count}分"
+        x_minutes:
+          one:   "約1分"
+          other: "%{count}分"
+        about_x_hours:
+          one:   "約1時間"
+          other: "約%{count}時間"
+        x_days:
+          one:   "1日"
+          other: "%{count}日"
+        about_x_months:
+          one:   "約1ヶ月"
+          other: "約%{count}ヶ月"
+        x_months:
+          one:   "1ヶ月"
+          other: "%{count}ヶ月"
+        almost_x_years:
+          one:   "１年弱"
+          other: "%{count}年弱"
+        about_x_years:
+          one:   "約1年"
+          other: "約%{count}年"
+        over_x_years:
+          one:   "1年以上"
+          other: "%{count}年以上"

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Tasks', type: :system, js: true do
     end
 
     subject do 
-      task = all('h2')
+      task = all('h5')
       task_0 = task[0]
     end
 


### PR DESCRIPTION
## 対象step
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9720-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86

## 概要
bootstrapを導入し、全ページのデザインを整えました。また、それにあたって不必要と思われた箇所は削除・表記修正しております。（一覧ページの説明欄、作成時刻など）

## 画面イメージ
全て中央寄せで実装しております。

<img width="936" alt="スクリーンショット 2020-06-30 16 10 04" src="https://user-images.githubusercontent.com/50566849/86095902-85060080-baed-11ea-8a36-af3ef8ca8dcf.png">
<img width="771" alt="スクリーンショット 2020-06-30 16 10 18" src="https://user-images.githubusercontent.com/50566849/86095915-88998780-baed-11ea-9896-3b1d5288ddf1.png">
<img width="696" alt="スクリーンショット 2020-06-30 16 12 53" src="https://user-images.githubusercontent.com/50566849/86095919-89321e00-baed-11ea-9238-84073d1030c3.png">
<img width="847" alt="スクリーンショット 2020-06-30 16 10 26" src="https://user-images.githubusercontent.com/50566849/86095921-89cab480-baed-11ea-9cab-5cfb3eb97626.png">
<img width="713" alt="スクリーンショット 2020-06-30 16 11 49" src="https://user-images.githubusercontent.com/50566849/86095924-8a634b00-baed-11ea-9566-262768bff82b.png">
<img width="606" alt="スクリーンショット 2020-06-30 16 13 21" src="https://user-images.githubusercontent.com/50566849/86095930-8b947800-baed-11ea-8a67-04bc4e05d17f.png">


## 実施した改修内容
- bootstrap CDNを導入
- タスク関係の全てのviewファイルにbootstrapクラスを適用
- エラーメッセージにbootstrapクラスを適用
- フラッシュメッセージにbootstrapクラスを適用
- 終了日時の表記を簡略化
- 作成日時、更新日時の表記を「〜前」といったものに変更
- タスク一覧ページにて説明欄を削除
- タスク一覧ページにて更新時刻欄を削除
- ページネーションを5に変更
- system_specを修正

## 確認していただきたい点
- レイアウトに不備がないかどうか
